### PR TITLE
ci: reduce redundant workflow overhead

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,15 @@
 name: Docker build
 
-on: [push, pull_request]
+on:
+  push:
+    branches: ["main"]
+    tags: ["*"]
+  pull_request:
+    branches: ["main"]
+
+concurrency:
+  group: docker-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -21,7 +30,37 @@ jobs:
         id: versions
         run: python scripts/ci_versions.py
 
-  build:
+  pr-smoke:
+    if: github.event_name == 'pull_request'
+    needs: versions
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build runtime image for PR smoke test
+        uses: docker/build-push-action@v6
+        with:
+          cache-from: type=gha,scope=docker-runtime
+          cache-to: type=gha,mode=max,scope=docker-runtime
+          push: false
+          load: true
+          build-args: |
+            PYTHON_VERSION=${{ needs.versions.outputs.default-python }}
+            UV_VERSION=${{ needs.versions.outputs.uv-version }}
+            QLINKS_EXTRAS=
+          tags: qlinks:ci-runtime
+
+      - name: Smoke test runtime image
+        run: >-
+          docker run --rm qlinks:ci-runtime
+          python -c "import qlinks; print('qlinks import OK')"
+
+  publish:
+    if: github.event_name == 'push'
     needs: versions
     runs-on: ubuntu-latest
 
@@ -34,28 +73,16 @@ jobs:
             floating-tag: latest
             python-version: ${{ needs.versions.outputs.default-python }}
             extras: ""
-            pr-smoke: true
-            smoke-command: >-
-              import qlinks;
-              print('qlinks import OK')
           - variant: notebook
             tag-suffix: -notebook
             floating-tag: notebook
             python-version: ${{ needs.versions.outputs.default-python }}
             extras: notebook drawing storage
-            pr-smoke: false
-            smoke-command: >-
-              import ipykernel, jupyterlab, qlinks;
-              print('qlinks notebook image OK')
           - variant: tn-notebook
             tag-suffix: -tn-notebook
             floating-tag: tn-notebook
             python-version: "3.13"
             extras: notebook tn drawing storage
-            pr-smoke: false
-            smoke-command: >-
-              import autograd, ipykernel, jupyterlab, qlinks, quimb;
-              print('qlinks TN notebook image OK')
 
     steps:
       - uses: actions/checkout@v4
@@ -74,20 +101,17 @@ jobs:
           tags: |
             type=ref,event=branch,suffix=${{ matrix.tag-suffix }}
             type=ref,event=tag,suffix=${{ matrix.tag-suffix }}
-            type=ref,event=pr,suffix=${{ matrix.tag-suffix }}
             type=sha,format=long,suffix=${{ matrix.tag-suffix }}
-            type=raw,value={{date 'YYYYMMDD-hhmmss' tz='Asia/Taipei'}}${{ matrix.tag-suffix }},enable=${{ github.event_name == 'push' }}
+            type=raw,value={{date 'YYYYMMDD-hhmmss' tz='Asia/Taipei'}}${{ matrix.tag-suffix }}
             type=raw,value=${{ matrix.floating-tag }},enable={{is_default_branch}}
 
       - name: Login to DockerHub
-        if: github.event_name == 'push'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push Docker image
-        if: github.event_name == 'push'
         uses: docker/build-push-action@v6
         with:
           cache-from: type=gha,scope=docker-${{ matrix.variant }}
@@ -99,24 +123,3 @@ jobs:
             QLINKS_EXTRAS=${{ matrix.extras }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Build Docker image for PR smoke test
-        if: github.event_name == 'pull_request' && matrix.pr-smoke
-        uses: docker/build-push-action@v6
-        with:
-          cache-from: type=gha,scope=docker-${{ matrix.variant }}
-          cache-to: type=gha,mode=max,scope=docker-${{ matrix.variant }}
-          push: false
-          load: true
-          build-args: |
-            PYTHON_VERSION=${{ matrix.python-version }}
-            UV_VERSION=${{ needs.versions.outputs.uv-version }}
-            QLINKS_EXTRAS=${{ matrix.extras }}
-          tags: qlinks:ci-${{ matrix.variant }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Smoke test Docker image
-        if: github.event_name == 'pull_request' && matrix.pr-smoke
-        run: >-
-          docker run --rm qlinks:ci-${{ matrix.variant }}
-          python -c "${{ matrix.smoke-command }}"

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,6 +1,14 @@
 name: Doc
 
-on: [push, pull_request]
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+concurrency:
+  group: docs-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,14 @@
 name: Lint
 
-on: [push, pull_request]
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+concurrency:
+  group: lint-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -45,7 +53,7 @@ jobs:
   advisory:
     needs: versions
     runs-on: ubuntu-latest
-    continue-on-error: true  # mypy/security/cruft reports are advisory for now.
+    continue-on-error: true  # mypy/security reports are advisory for now.
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,9 @@ name: Test
 
 on:
   push:
+    branches: ["main"]
   pull_request:
+    branches: ["main"]
   workflow_dispatch:
 
 concurrency:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,12 +41,6 @@ repos:
 
 -   repo: local
     hooks:
-    -   id: cruft-check
-        name: cruft-check
-        entry: uv run cruft check
-        language: system
-        pass_filenames: false
-        stages: [pre-push]
     -   id: uv-lock-check
         name: uv lock check
         entry: uv lock --check

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:base",
+    "schedule:monthly"
   ],
+  "timezone": "Asia/Taipei",
+  "updateNotScheduled": false,
   "pre-commit": {
     "enabled": true
   }

--- a/scripts/lint_advisory.sh
+++ b/scripts/lint_advisory.sh
@@ -13,7 +13,6 @@ _advisory() {
     fi
 }
 
-_advisory "cruft" uv run cruft check
 # Safety CLI v3 prompts for login in non-interactive CI.
 # Keep dependency vulnerability checks out of advisory lint until a
 # non-interactive scanner is pinned in the lockfile.


### PR DESCRIPTION
## Summary

Follow-up to #96 focused on CI latency and redundant work.

- stop running duplicate feature-branch `push` copies of PR validation; keep PR checks and post-merge `main` validation
- cancel superseded lint/test/docs/Docker runs with workflow concurrency groups
- reduce PR Docker validation to one runtime image smoke build; keep all runtime/notebook/TN publishes on `main` and tags
- remove the stale cruft template check from pre-commit and advisory lint
- restrict Renovate branch creation/updates to its monthly schedule in `Asia/Taipei`

## Audit notes

The final #96 head was triggering both push- and pull-request copies of the same validation. Documentation was the longest repeated path (roughly 4.5 minutes per copy), while its environment setup was only a small fraction of that time. This PR removes the low-risk duplication first rather than weakening documentation validation.

## Validation

- YAML/JSON configuration syntax checked locally
- branch is one commit ahead of current `main`, with only CI/tooling configuration changes

A later CI pass can profile the Sphinx/architecture-build internals separately if documentation remains the critical path after these trigger changes.