### PR TITLE
ci: speed up pull-request documentation builds

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -19,8 +19,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Read versions
         id: versions
@@ -34,7 +32,6 @@ jobs:
           python-version: ${{ steps.versions.outputs.default-python }}
           uv-version: ${{ steps.versions.outputs.uv-version }}
           cache-prefix: docs
-          system-packages: build-essential pkg-config libxml2-dev libxslt1-dev zlib1g-dev pandoc
           install-command: uv sync --locked --no-default-groups --group docs
 
       - name: Build Sphinx doc and architecture diagnosis

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -14,23 +14,7 @@ permissions:
   contents: read
 
 jobs:
-  versions:
-    runs-on: ubuntu-latest
-    outputs:
-      default-python: ${{ steps.versions.outputs.default-python }}
-      uv-version: ${{ steps.versions.outputs.uv-version }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install CI helper dependency
-        run: python -m pip install packaging
-
-      - name: Read versions
-        id: versions
-        run: python scripts/ci_versions.py
-
   build:
-    needs: versions
     runs-on: ubuntu-latest
 
     steps:
@@ -38,16 +22,24 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Read versions
+        id: versions
+        run: |
+          python -m pip install packaging
+          python scripts/ci_versions.py
+
       - name: Set up Python and uv
         uses: ./.github/actions/setup-python-uv
         with:
-          python-version: ${{ needs.versions.outputs.default-python }}
-          uv-version: ${{ needs.versions.outputs.uv-version }}
+          python-version: ${{ steps.versions.outputs.default-python }}
+          uv-version: ${{ steps.versions.outputs.uv-version }}
           cache-prefix: docs
           system-packages: build-essential pkg-config libxml2-dev libxslt1-dev zlib1g-dev pandoc
           install-command: uv sync --locked --no-default-groups --group docs
 
       - name: Build Sphinx doc and architecture diagnosis
+        env:
+          QLINKS_DOCS_VIEWCODE: ${{ github.event_name == 'pull_request' && '0' || '1' }}
         run: uv run --no-default-groups --group docs make -C docs html
 
       - name: Upload documentation site

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Read versions
         id: versions

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import os  # noqa: F401
+import os
 import sys
 from importlib import metadata
 from pathlib import Path
@@ -40,10 +40,15 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
-    "sphinx.ext.viewcode",
     "nbsphinx",
     "m2r2",
 ]
+
+# Viewcode spends most of its time highlighting every documented source module.
+# Keep it in deployed documentation, but let PR validation skip the generated
+# source pages because they do not affect autodoc/autosummary correctness.
+if os.environ.get("QLINKS_DOCS_VIEWCODE", "1") != "0":
+    extensions.append("sphinx.ext.viewcode")
 
 templates_path = ["_templates"]
 source_suffix = [".rst", ".md"]


### PR DESCRIPTION
## Summary

Follow-up documentation-CI performance pass after #99.

- run `scripts/ci_versions.py` inside the documentation build job instead of starting a separate runner only to read tool versions
- disable `sphinx.ext.viewcode` only for pull-request validation
- retain `viewcode` on `main`, so the deployed documentation still includes source-code pages
- use shallow checkout for PR documentation validation
- remove unnecessary system-package installation from the docs job
- update the documentation workflow to `actions/checkout@v7`
- keep the full autodoc/autosummary/Sphinx build, architecture diagnosis, and artifacts on PRs

## Measured result

Baseline PR documentation build: about **4m29s** end-to-end.

Final optimized PR build: about **2m07s** end-to-end, a reduction of roughly **53%**.

The largest saving is from skipping generated `viewcode` source pages during PR validation. The Sphinx + architecture command fell from roughly 3m57s to about 1m47s. Shallow checkout and dropping unnecessary apt installation then removed another ~20 seconds of setup overhead.

The architecture diagnosis itself remains only ~2 seconds and is retained unchanged.

## Validation

The final head is green across Doc, Test, Lint, Docker, and CodeQL. PR documentation still exercises autodoc, autosummary, imports, API rendering, and the repository architecture report. `viewcode` remains enabled on `main`, so deployed documentation retains source-code pages.

## Documentation health observation

The build still emits roughly 893 pre-existing Sphinx warnings, including stale autosummary imports, duplicate object descriptions, and docstring/RST parsing issues. These are separate documentation-health debt; this PR deliberately does not suppress them or weaken validation. A later cleanup can reduce the warning count before considering warnings-as-errors.