### PR TITLE
ci: restore lxml build dependencies for docs

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -32,6 +32,7 @@ jobs:
           python-version: ${{ steps.versions.outputs.default-python }}
           uv-version: ${{ steps.versions.outputs.uv-version }}
           cache-prefix: docs
+          system-packages: libxml2-dev libxslt1-dev
           install-command: uv sync --locked --no-default-groups --group docs
 
       - name: Build Sphinx doc and architecture diagnosis


### PR DESCRIPTION
## Root cause

The post-merge Doc run after #103 failed before Sphinx started. A clean `uv sync --locked --no-default-groups --group docs` on Python 3.14 selected `lxml==5.4.0`, which has to build from source in this environment. The optimized Doc workflow from #102 had removed the XML/XSLT development packages, so the build failed with:

> Error: Please make sure the libxml2 and libxslt development packages are installed.

The #102 PR remained green because its docs cache already contained the dependency; #103 changed the lock/cache key and exposed the missing clean-install prerequisite.

## Fix

Restore only the native packages required by the current `lxml` source build through the existing composite-action input:

- `libxml2-dev`
- `libxslt1-dev`

All other #102 Doc-CI optimizations remain unchanged: shallow checkout, single build job, PR-only `viewcode` disablement, and the full Sphinx/autodoc/architecture validation.

## Scope

One workflow line; no Python or dependency changes.