### PR TITLE
ci: enforce pre-commit policy for API changes

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,66 @@
+name: Pre-commit
+
+on:
+  push:
+  pull_request:
+    branches: ["main"]
+
+concurrency:
+  group: pre-commit-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  policy:
+    # Same-repository PRs are already covered by the push run for the exact head
+    # SHA. Fork PRs do not produce a push event in this repository, so validate
+    # them from the pull_request event instead.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Install CI helper dependency
+        run: python -m pip install packaging
+
+      - name: Read versions
+        id: versions
+        run: python .github/scripts/ci_versions.py
+
+      - name: Set up Python and uv
+        uses: ./.github/actions/setup-python-uv
+        with:
+          python-version: ${{ steps.versions.outputs.default-python }}
+          uv-version: ${{ steps.versions.outputs.uv-version }}
+          cache-prefix: pre-commit
+          system-packages: build-essential pkg-config libxml2-dev libxslt1-dev zlib1g-dev
+          install-command: uv sync --locked
+
+      - name: Determine validation range
+        id: range
+        shell: bash
+        env:
+          EVENT_BEFORE: ${{ github.event.before }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          zero=0000000000000000000000000000000000000000
+
+          if [[ "${GITHUB_EVENT_NAME}" == "push" \
+                && "${GITHUB_REF}" == "refs/heads/${DEFAULT_BRANCH}" \
+                && "${EVENT_BEFORE:-${zero}}" != "${zero}" ]]; then
+            base="${EVENT_BEFORE}"
+          else
+            git fetch --no-tags origin "${DEFAULT_BRANCH}"
+            base="$(git merge-base "origin/${DEFAULT_BRANCH}" HEAD)"
+          fi
+
+          echo "base=${base}" >> "${GITHUB_OUTPUT}"
+
+      - name: Enforce pre-commit policy
+        run: ./scripts/dev/precommit_ci.sh "${{ steps.range.outputs.base }}" HEAD

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+default_install_hook_types: [pre-commit, commit-msg, pre-push]
+default_stages: [pre-commit]
+
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/scripts/dev/precommit_ci.sh
+++ b/scripts/dev/precommit_ci.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+base_ref="${1:?usage: precommit_ci.sh BASE_REF [HEAD_REF]}"
+head_ref="${2:-HEAD}"
+
+# Keep API- or web-created commits subject to the same repository policy as
+# ordinary local git commits. File hooks are evaluated on the branch diff;
+# repository-wide pre-push checks are replayed explicitly below.
+uv run pre-commit validate-config
+uv run pre-commit run \
+  --from-ref "${base_ref}" \
+  --to-ref "${head_ref}" \
+  --hook-stage pre-commit \
+  --show-diff-on-failure
+
+uv run pre-commit run uv-lock-check \
+  --all-files \
+  --hook-stage pre-push \
+  --show-diff-on-failure
+uv run pre-commit run test-health \
+  --all-files \
+  --hook-stage pre-push \
+  --show-diff-on-failure
+
+# commit-msg hooks cannot run retroactively on GitHub API commits. Commitizen's
+# branch check is the CI-equivalent: validate every commit unique to this range.
+uv run cz check --rev-range "${base_ref}..${head_ref}"


### PR DESCRIPTION
## Summary

Make the repository's pre-commit policy apply mechanically to both ordinary local git work and GitHub App/API-created commits.

### Local git

- `pre-commit install` now installs `pre-commit`, `commit-msg`, and `pre-push` hooks by default.
- unspecified hooks default to the `pre-commit` stage, while Commitizen and the existing uv-lock/test-health hooks retain their explicit stages.

### GitHub App / API / web commits

Add a dedicated `Pre-commit` workflow that runs on every repository push. It replays:

- pre-commit file hooks across the full branch diff from `main`;
- `uv-lock-check` and local test-health pre-push checks;
- Commitizen validation across every commit unique to the branch.

Same-repository PR events skip the duplicate job because the exact head SHA is already validated by the push event; fork PRs still receive a pull-request validation run.

The shared runner lives at `scripts/dev/precommit_ci.sh` so CI behavior is explicit and locally reproducible.

## Why

GitHub App/API commits do not execute local `.git/hooks`, so the prior configuration could be bypassed unintentionally. This makes the remote check the required development gate before an API-authored change is considered ready for review.

## Validation

The commit itself follows Commitizen and the new push workflow is expected to validate this branch end-to-end.