### PR TITLE
fix: preserve Docker uv environment under bind mounts

### DIFF
--- a/.github/actions/setup-python-uv/action.yml
+++ b/.github/actions/setup-python-uv/action.yml
@@ -41,8 +41,18 @@ runs:
       if: inputs.system-packages != ''
       shell: bash
       run: |
-        sudo apt-get update
-        sudo apt-get install -y ${{ inputs.system-packages }}
+        sudo env DEBIAN_FRONTEND=noninteractive timeout 180s \
+          apt-get \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=20 \
+            -o Acquire::https::Timeout=20 \
+            update
+        sudo env DEBIAN_FRONTEND=noninteractive timeout 180s \
+          apt-get \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=20 \
+            -o Acquire::https::Timeout=20 \
+            install -y --no-install-recommends ${{ inputs.system-packages }}
 
     - name: Set up uv
       uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,10 +54,13 @@ jobs:
             QLINKS_EXTRAS=
           tags: qlinks:ci-runtime
 
-      - name: Smoke test runtime image
-        run: >-
-          docker run --rm qlinks:ci-runtime
-          python -c "import qlinks; print('qlinks import OK')"
+      - name: Smoke test runtime image with repository bind mount
+        run: |
+          docker run --rm \
+            --volume "${GITHUB_WORKSPACE}:/workspace/qlinks" \
+            --workdir /workspace/qlinks \
+            qlinks:ci-runtime \
+            python -c "import sys, matplotlib, qlinks; assert sys.executable == '/opt/qlinks-venv/bin/python', sys.executable; print('bind-mounted qlinks environment OK:', sys.executable)"
 
   publish:
     if: github.event_name == 'push'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,7 +44,6 @@ jobs:
           python-version: ${{ needs.versions.outputs.default-python }}
           uv-version: ${{ needs.versions.outputs.uv-version }}
           cache-prefix: lint-blocking
-          system-packages: build-essential pkg-config libxml2-dev libxslt1-dev zlib1g-dev
           install-command: uv sync --locked
 
       - name: Blocking lint
@@ -66,7 +65,6 @@ jobs:
           python-version: ${{ needs.versions.outputs.default-python }}
           uv-version: ${{ needs.versions.outputs.uv-version }}
           cache-prefix: lint-advisory
-          system-packages: build-essential pkg-config libxml2-dev libxslt1-dev zlib1g-dev
           install-command: uv sync --locked
 
       - name: Advisory lint

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -38,7 +38,6 @@ jobs:
           python-version: ${{ steps.versions.outputs.default-python }}
           uv-version: ${{ steps.versions.outputs.uv-version }}
           cache-prefix: pre-commit
-          system-packages: build-essential pkg-config libxml2-dev libxslt1-dev zlib1g-dev
           install-command: uv sync --locked
 
       - name: Determine validation range

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,9 +48,8 @@ jobs:
           uv-version: ${{ needs.versions.outputs.uv-version }}
           cache-prefix: test-fast
           compile-paths: qlinks tests
-          system-packages: >-
-            build-essential gfortran libblas-dev liblapack-dev pkg-config
-            libcairo2-dev libxml2-dev libxslt1-dev zlib1g-dev
+          # Pycairo is built from source on Linux and needs Cairo headers.
+          system-packages: pkg-config libcairo2-dev
           install-command: uv sync --locked --extra storage --extra drawing
 
       - name: Run fast test lane
@@ -94,7 +93,6 @@ jobs:
           uv-version: ${{ needs.versions.outputs.uv-version }}
           cache-prefix: test-compatibility
           compile-paths: qlinks tests
-          system-packages: build-essential gfortran libblas-dev liblapack-dev pkg-config
           install-command: uv sync --locked --extra storage
 
       - name: Run fast test lane without coverage
@@ -117,9 +115,8 @@ jobs:
           uv-version: ${{ needs.versions.outputs.uv-version }}
           cache-prefix: test-integration
           compile-paths: qlinks tests
-          system-packages: >-
-            build-essential gfortran libblas-dev liblapack-dev pkg-config
-            libcairo2-dev libxml2-dev libxslt1-dev zlib1g-dev
+          # Pycairo is built from source on Linux and needs Cairo headers.
+          system-packages: pkg-config libcairo2-dev
           install-command: uv sync --locked --extra storage --extra drawing
 
       - name: Run integration test lane
@@ -163,7 +160,6 @@ jobs:
           uv-version: ${{ needs.versions.outputs.uv-version }}
           cache-prefix: test-tn
           compile-paths: qlinks tests
-          system-packages: build-essential gfortran libblas-dev liblapack-dev pkg-config
           install-command: uv sync --locked --extra tn
 
       - name: Verify tensor-network environment

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,16 @@ ARG TARGETARCH
 # --build-arg PYTHON_VERSION=3.13 --build-arg QLINKS_EXTRAS=tn.
 # ``notebook`` is a Docker feature backed by qlinks' non-default uv dependency group;
 # other feature names map to project extras.
+#
+# The project source is bind-mounted over /workspace/qlinks by the evidence-job
+# launcher. Keep the uv environment outside that mount so the image-installed
+# dependencies remain visible when local source replaces the image source tree.
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     UV_LINK_MODE=copy \
-    PATH="/workspace/qlinks/.venv/bin:${PATH}"
+    UV_PROJECT_ENVIRONMENT=/opt/qlinks-venv \
+    PATH="/opt/qlinks-venv/bin:${PATH}"
 
 WORKDIR /workspace/qlinks
 
@@ -68,7 +73,7 @@ RUN set -- --no-default-groups && \
         fi; \
     done && \
     uv sync --locked "$@" && \
-    .venv/bin/python scripts/docker/verify_optional_environment.py --extras "${QLINKS_EXTRAS}"
+    python scripts/docker/verify_optional_environment.py --extras "${QLINKS_EXTRAS}"
 
-# PyCharm can use the project virtual environment's Python directly.
+# PyCharm can use /opt/qlinks-venv/bin/python directly.
 CMD ["python"]


### PR DESCRIPTION
## Summary

Fix evidence containers losing their uv-installed dependencies when the host repository is bind-mounted over `/workspace/qlinks`, and harden CI setup against package-manager stalls exposed while validating the fix.

## Root cause

The Docker image currently creates its uv environment at `/workspace/qlinks/.venv` and prepends that path to `PATH`. The evidence launcher then bind-mounts the host repository onto `/workspace/qlinks`, which hides the image-created `.venv`. As a result `python` falls back to `/usr/local/bin/python`; base dependencies such as `matplotlib` are then unavailable.

This is not an extras-pairing problem: `matplotlib` is a base project dependency.

## Docker fix

- set `UV_PROJECT_ENVIRONMENT=/opt/qlinks-venv` in the image;
- prepend `/opt/qlinks-venv/bin` to `PATH`;
- run optional-environment verification through the active `python` rather than a repository-local `.venv/bin/python` path;
- strengthen the PR Docker smoke test by bind-mounting the checkout at `/workspace/qlinks`, importing both `matplotlib` and `qlinks`, and asserting the interpreter is `/opt/qlinks-venv/bin/python`.

The smoke test now reproduces the same mount topology used by `scripts/docker/docker_run_evidence_job.sh`, so this regression should be caught mechanically in future Docker changes.

## CI setup hardening

The first validation run exposed multiple jobs spending excessive time inside the shared Python/uv setup rather than in pytest or Ruff. The follow-up commit therefore:

- removes unnecessary apt build dependencies from both lint jobs;
- removes unnecessary compiler/BLAS/LAPACK packages from compatibility and tensor-network test lanes;
- retains only `pkg-config` and `libcairo2-dev` in drawing-enabled lanes, where Pycairo needs native Cairo headers;
- removes the unnecessary apt layer from the remote pre-commit policy job;
- bounds remaining apt operations with retries and 180-second timeouts and uses `--no-install-recommends`.

This leaves native package installation only where it is required by the selected dependency set, while making package-mirror stalls fail clearly instead of occupying a runner indefinitely.

## Expected operational effect

After merge and publication of the refreshed `tanlin2013/qlinks:notebook` image, the existing evidence-job command can remain unchanged. The project source/data mounts stay live, while the image-provisioned Python environment is no longer shadowed by the repository bind mount.

The failed spin-1 job was already in its render phase, so the expensive numerical computation does not need to be repeated; rendering can be rerun against the existing `spin1_production_20260810T082123Z` evidence directory once the refreshed image is available.