### PR TITLE
ci: clarify policy gates and harden apt setup

### DIFF
--- a/.github/actions/setup-python-uv/action.yml
+++ b/.github/actions/setup-python-uv/action.yml
@@ -37,22 +37,54 @@ runs:
       shell: bash
       run: python -m compileall -q ${{ inputs.compile-paths }}
 
-    - name: Install system dependencies
+    - name: Install missing system dependencies
       if: inputs.system-packages != ''
       shell: bash
       run: |
-        sudo env DEBIAN_FRONTEND=noninteractive timeout 180s \
+        set -euo pipefail
+
+        read -r -a requested <<< "${{ inputs.system-packages }}"
+        missing=()
+        for package in "${requested[@]}"; do
+          if ! dpkg-query -W -f='${db:Status-Abbrev}' "${package}" 2>/dev/null | grep -q '^ii'; then
+            missing+=("${package}")
+          fi
+        done
+
+        if ((${#missing[@]} == 0)); then
+          echo "All requested system packages are already installed."
+          exit 0
+        fi
+
+        echo "Missing system packages: ${missing[*]}"
+
+        install_missing() {
+          sudo env DEBIAN_FRONTEND=noninteractive timeout 60s \
+            apt-get \
+              -o Acquire::Retries=2 \
+              -o Acquire::http::Timeout=15 \
+              -o Acquire::https::Timeout=15 \
+              -o DPkg::Lock::Timeout=20 \
+              -o Dpkg::Use-Pty=0 \
+              install -y --no-install-recommends "${missing[@]}"
+        }
+
+        # GitHub-hosted runners already carry usable apt indexes. Avoid a fresh
+        # mirror-wide `apt-get update` on the normal path; it has been our main
+        # source of intermittent setup stalls. Refresh indexes only if the
+        # direct installation fails, then retry once.
+        if install_missing; then
+          exit 0
+        fi
+
+        echo "::warning::Direct apt install failed; refreshing package indexes once before retrying."
+        sudo env DEBIAN_FRONTEND=noninteractive timeout 60s \
           apt-get \
-            -o Acquire::Retries=3 \
-            -o Acquire::http::Timeout=20 \
-            -o Acquire::https::Timeout=20 \
+            -o Acquire::Retries=2 \
+            -o Acquire::http::Timeout=15 \
+            -o Acquire::https::Timeout=15 \
             update
-        sudo env DEBIAN_FRONTEND=noninteractive timeout 180s \
-          apt-get \
-            -o Acquire::Retries=3 \
-            -o Acquire::http::Timeout=20 \
-            -o Acquire::https::Timeout=20 \
-            install -y --no-install-recommends ${{ inputs.system-packages }}
+        install_missing
 
     - name: Set up uv
       uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build runtime image for PR smoke test
+      # Native Cairo belongs to the container boundary. The Dockerfile's
+      # libcairo development layer is stable/cacheable, unlike fresh apt setup
+      # on every GitHub-hosted Fast and Integration runner.
+      - name: Build drawing runtime image for PR smoke test
         uses: docker/build-push-action@v6
         with:
           cache-from: type=gha,scope=docker-runtime
@@ -51,16 +54,21 @@ jobs:
           build-args: |
             PYTHON_VERSION=${{ needs.versions.outputs.default-python }}
             UV_VERSION=${{ needs.versions.outputs.uv-version }}
-            QLINKS_EXTRAS=
+            QLINKS_EXTRAS=drawing storage
           tags: qlinks:ci-runtime
 
-      - name: Smoke test runtime image with repository bind mount
+      - name: Smoke test bind mount and Cairo drawing backend
         run: |
           docker run --rm \
             --volume "${GITHUB_WORKSPACE}:/workspace/qlinks" \
             --workdir /workspace/qlinks \
             qlinks:ci-runtime \
-            python -c "import sys, matplotlib, qlinks; assert sys.executable == '/opt/qlinks-venv/bin/python', sys.executable; print('bind-mounted qlinks environment OK:', sys.executable)"
+            bash -lc '
+              set -euo pipefail
+              python -c "import sys, cairo, igraph, matplotlib, qlinks; assert sys.executable == '\''/opt/qlinks-venv/bin/python'\'', sys.executable; print('\''bind-mounted drawing environment OK:'\'', sys.executable)"
+              uv sync --locked --extra storage --extra drawing
+              QLINKS_TEST_COVERAGE=0 scripts/dev/test.sh fast tests/visualizer/test_hamiltonian_graph.py
+            '
 
   publish:
     if: github.event_name == 'push'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
             --volume "${GITHUB_WORKSPACE}:/workspace/qlinks" \
             --workdir /workspace/qlinks \
             qlinks:ci-runtime \
-            bash -lc '
+            bash -c '
               set -euo pipefail
               python -c "import sys, cairo, igraph, matplotlib, qlinks; assert sys.executable == '\''/opt/qlinks-venv/bin/python'\'', sys.executable; print('\''bind-mounted drawing environment OK:'\'', sys.executable)"
               uv sync --locked --extra storage --extra drawing

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,8 +46,11 @@ jobs:
           cache-prefix: lint-blocking
           install-command: uv sync --locked
 
-      - name: Blocking lint
-        run: ./scripts/dev/lint_blocking.sh
+      - name: Ruff
+        run: ./scripts/dev/lint_blocking.sh ruff
+
+      - name: Repository health
+        run: ./scripts/dev/lint_blocking.sh repository-health
 
   advisory:
     needs: versions

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,6 +37,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Set up Python and uv
         uses: ./.github/actions/setup-python-uv
@@ -61,6 +62,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Set up Python and uv
         uses: ./.github/actions/setup-python-uv

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Install CI helper dependency
         run: python -m pip install packaging

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,12 +1,13 @@
-name: Pre-commit
+name: Policy
 
 on:
   push:
+    branches: ["main"]
   pull_request:
     branches: ["main"]
 
 concurrency:
-  group: pre-commit-${{ github.event.pull_request.number || github.ref }}
+  group: policy-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -14,10 +15,6 @@ permissions:
 
 jobs:
   policy:
-    # Same-repository PRs are already covered by the push run for the exact head
-    # SHA. Fork PRs do not produce a push event in this repository, so validate
-    # them from the pull_request event instead.
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
 
     steps:
@@ -37,7 +34,7 @@ jobs:
         with:
           python-version: ${{ steps.versions.outputs.default-python }}
           uv-version: ${{ steps.versions.outputs.uv-version }}
-          cache-prefix: pre-commit
+          cache-prefix: policy
           install-command: uv sync --locked
 
       - name: Determine validation range
@@ -61,5 +58,17 @@ jobs:
 
           echo "base=${base}" >> "${GITHUB_OUTPUT}"
 
-      - name: Enforce pre-commit policy
-        run: ./scripts/dev/precommit_ci.sh "${{ steps.range.outputs.base }}" HEAD
+      - name: File hygiene and notebook normalization
+        run: ./scripts/dev/precommit_ci.sh "${{ steps.range.outputs.base }}" HEAD files
+
+      - name: Repository health
+        run: ./scripts/dev/precommit_ci.sh "${{ steps.range.outputs.base }}" HEAD repository-health
+
+      - name: Dependency lock
+        run: ./scripts/dev/precommit_ci.sh "${{ steps.range.outputs.base }}" HEAD lock
+
+      - name: Test-suite health
+        run: ./scripts/dev/precommit_ci.sh "${{ steps.range.outputs.base }}" HEAD test-health
+
+      - name: Commit message policy
+        run: ./scripts/dev/precommit_ci.sh "${{ steps.range.outputs.base }}" HEAD commits

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -61,14 +61,8 @@ jobs:
       - name: File hygiene and notebook normalization
         run: ./scripts/dev/precommit_ci.sh "${{ steps.range.outputs.base }}" HEAD files
 
-      - name: Repository health
-        run: ./scripts/dev/precommit_ci.sh "${{ steps.range.outputs.base }}" HEAD repository-health
-
       - name: Dependency lock
         run: ./scripts/dev/precommit_ci.sh "${{ steps.range.outputs.base }}" HEAD lock
-
-      - name: Test-suite health
-        run: ./scripts/dev/precommit_ci.sh "${{ steps.range.outputs.base }}" HEAD test-health
 
       - name: Commit message policy
         run: ./scripts/dev/precommit_ci.sh "${{ steps.range.outputs.base }}" HEAD commits

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Set up Python and uv
         uses: ./.github/actions/setup-python-uv
@@ -48,10 +49,11 @@ jobs:
           uv-version: ${{ needs.versions.outputs.uv-version }}
           cache-prefix: test-fast
           compile-paths: qlinks tests
-          # Pycairo is built from source on Linux. pkg-config is preinstalled on
-          # GitHub's Ubuntu image; only the missing Cairo headers are requested.
-          system-packages: libcairo2-dev
-          install-command: uv sync --locked --extra storage --extra drawing
+          # Native drawing/Cairo validation belongs to the required Docker build
+          # gate, where the system toolchain is part of a cacheable image layer.
+          # Keep the ordinary fast lane pure-Python/uv so Ubuntu apt mirrors
+          # cannot block unrelated package and unit-test validation.
+          install-command: uv sync --locked --extra storage
 
       - name: Run fast test lane
         env:
@@ -116,10 +118,9 @@ jobs:
           uv-version: ${{ needs.versions.outputs.uv-version }}
           cache-prefix: test-integration
           compile-paths: qlinks tests
-          # Pycairo is built from source on Linux. pkg-config is preinstalled on
-          # GitHub's Ubuntu image; only the missing Cairo headers are requested.
-          system-packages: libcairo2-dev
-          install-command: uv sync --locked --extra storage --extra drawing
+          # Optional native drawing tests run in Docker; this lane owns the
+          # cross-module integration suite without host system-package setup.
+          install-command: uv sync --locked --extra storage
 
       - name: Run integration test lane
         run: scripts/dev/test.sh integration

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,15 @@ jobs:
           QLINKS_COVERAGE_XML: "1"
         run: scripts/dev/test.sh fast
 
+      - name: Test-suite health
+        run: |
+          uv run python tools/test_health.py \
+            --check \
+            --json "${RUNNER_TEMP}/test-health.json" \
+            --markdown "${RUNNER_TEMP}/test-health.md" \
+            --quiet
+          cat "${RUNNER_TEMP}/test-health.md" >> "${GITHUB_STEP_SUMMARY}"
+
       - name: Report coverage
         if: github.ref_name == 'main'
         uses: codecov/codecov-action@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,23 +48,15 @@ jobs:
           uv-version: ${{ needs.versions.outputs.uv-version }}
           cache-prefix: test-fast
           compile-paths: qlinks tests
-          # Pycairo is built from source on Linux and needs Cairo headers.
-          system-packages: pkg-config libcairo2-dev
+          # Pycairo is built from source on Linux. pkg-config is preinstalled on
+          # GitHub's Ubuntu image; only the missing Cairo headers are requested.
+          system-packages: libcairo2-dev
           install-command: uv sync --locked --extra storage --extra drawing
 
       - name: Run fast test lane
         env:
           QLINKS_COVERAGE_XML: "1"
         run: scripts/dev/test.sh fast
-
-      - name: Check test-suite health
-        run: |
-          uv run python tools/test_health.py \
-            --check \
-            --json "${RUNNER_TEMP}/test-health.json" \
-            --markdown "${RUNNER_TEMP}/test-health.md" \
-            --quiet
-          cat "${RUNNER_TEMP}/test-health.md" >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Report coverage
         if: github.ref_name == 'main'
@@ -115,8 +107,9 @@ jobs:
           uv-version: ${{ needs.versions.outputs.uv-version }}
           cache-prefix: test-integration
           compile-paths: qlinks tests
-          # Pycairo is built from source on Linux and needs Cairo headers.
-          system-packages: pkg-config libcairo2-dev
+          # Pycairo is built from source on Linux. pkg-config is preinstalled on
+          # GitHub's Ubuntu image; only the missing Cairo headers are requested.
+          system-packages: libcairo2-dev
           install-command: uv sync --locked --extra storage --extra drawing
 
       - name: Run integration test lane

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,7 @@ repos:
     hooks:
     -   id: nbstripout
         files: \.ipynb$
+        args: ['--keep-id']
 
 -   repo: local
     hooks:

--- a/scripts/dev/lint_blocking.sh
+++ b/scripts/dev/lint_blocking.sh
@@ -1,21 +1,45 @@
 #!/bin/bash
 set -euxo pipefail
 
-# CI ownership boundary: this lane owns Ruff only. Repository/test/lock health
-# and notebook normalization belong to the Policy workflow.
-uv run ruff check qlinks/ tests/
-uv run ruff format --check qlinks/ tests/
+phase="${1:-all}"
 
-# Keep maintained Python/Jupyter outside qlinks/tests covered without forcing a
-# repository-wide cleanup of historical/archive material in the same PR.
-if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
-    git fetch --no-tags origin "${GITHUB_BASE_REF}"
-    base="$(git merge-base "origin/${GITHUB_BASE_REF}" HEAD)"
-    mapfile -t changed_python < <(
-        git diff --name-only --diff-filter=ACMR "${base}" HEAD -- '*.py' '*.pyi' '*.ipynb'
-    )
-    if ((${#changed_python[@]})); then
-        uv run ruff check "${changed_python[@]}"
-        uv run ruff format --check "${changed_python[@]}"
+run_ruff() {
+    uv run ruff check qlinks/ tests/
+    uv run ruff format --check qlinks/ tests/
+
+    # Keep maintained Python/Jupyter outside qlinks/tests covered without
+    # forcing a repository-wide cleanup of historical/archive material.
+    if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
+        git fetch --no-tags origin "${GITHUB_BASE_REF}"
+        base="$(git merge-base "origin/${GITHUB_BASE_REF}" HEAD)"
+        mapfile -t changed_python < <(
+            git diff --name-only --diff-filter=ACMR "${base}" HEAD -- '*.py' '*.pyi' '*.ipynb'
+        )
+        if ((${#changed_python[@]})); then
+            uv run ruff check "${changed_python[@]}"
+            uv run ruff format --check "${changed_python[@]}"
+        fi
     fi
-fi
+}
+
+run_repository_health() {
+    uv run python tools/repository_health.py --check
+}
+
+case "${phase}" in
+    ruff)
+        run_ruff
+        ;;
+    repository-health)
+        run_repository_health
+        ;;
+    all)
+        run_ruff
+        run_repository_health
+        ;;
+    *)
+        echo "unknown blocking-lint phase: ${phase}" >&2
+        echo "expected one of: ruff, repository-health, all" >&2
+        exit 2
+        ;;
+esac

--- a/scripts/dev/lint_blocking.sh
+++ b/scripts/dev/lint_blocking.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 set -euxo pipefail
 
+# CI ownership boundary: this lane owns Ruff only. Repository/test/lock health
+# and notebook normalization belong to the Policy workflow.
 uv run ruff check qlinks/ tests/
 uv run ruff format --check qlinks/ tests/
 
-# The pre-commit policy applies Ruff to every changed Python/Jupyter file, not
-# only package/tests. Mirror that contract in the ordinary PR lint lane so
-# experimental jobs and notebooks cannot make the PR look green while the
-# required push-only policy check is failing.
+# Keep maintained Python/Jupyter outside qlinks/tests covered without forcing a
+# repository-wide cleanup of historical/archive material in the same PR.
 if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
     git fetch --no-tags origin "${GITHUB_BASE_REF}"
     base="$(git merge-base "origin/${GITHUB_BASE_REF}" HEAD)"
@@ -19,5 +19,3 @@ if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
         uv run ruff format --check "${changed_python[@]}"
     fi
 fi
-
-uv run python tools/repository_health.py --check --quiet

--- a/scripts/dev/precommit_ci.sh
+++ b/scripts/dev/precommit_ci.sh
@@ -1,28 +1,77 @@
 #!/bin/bash
 set -euo pipefail
 
-base_ref="${1:?usage: precommit_ci.sh BASE_REF [HEAD_REF]}"
+base_ref="${1:?usage: precommit_ci.sh BASE_REF [HEAD_REF] [PHASE]}"
 head_ref="${2:-HEAD}"
+phase="${3:-all}"
 
-# Keep API- or web-created commits subject to the same repository policy as
-# ordinary local git commits. File hooks are evaluated on the branch diff;
-# repository-wide pre-push checks are replayed explicitly below.
-uv run pre-commit validate-config
-uv run pre-commit run \
-  --from-ref "${base_ref}" \
-  --to-ref "${head_ref}" \
-  --hook-stage pre-commit \
-  --show-diff-on-failure
+run_file_policy() {
+  uv run pre-commit validate-config
 
-uv run pre-commit run uv-lock-check \
-  --all-files \
-  --hook-stage pre-push \
-  --show-diff-on-failure
-uv run pre-commit run test-health \
-  --all-files \
-  --hook-stage pre-push \
-  --show-diff-on-failure
+  # CI ownership boundary: Ruff is verified by Lint / blocking and repository
+  # health has its own Policy step. The file-policy phase owns only repository
+  # hygiene and notebook normalization.
+  SKIP=ruff-check,ruff-format,repository-health \
+    uv run pre-commit run \
+      --from-ref "${base_ref}" \
+      --to-ref "${head_ref}" \
+      --hook-stage pre-commit \
+      --show-diff-on-failure
+}
 
-# commit-msg hooks cannot run retroactively on GitHub API commits. Commitizen's
-# branch check is the CI-equivalent: validate every commit unique to this range.
-uv run cz check --rev-range "${base_ref}..${head_ref}"
+run_repository_health() {
+  uv run pre-commit run repository-health \
+    --all-files \
+    --hook-stage pre-commit \
+    --show-diff-on-failure
+}
+
+run_lock_health() {
+  uv run pre-commit run uv-lock-check \
+    --all-files \
+    --hook-stage pre-push \
+    --show-diff-on-failure
+}
+
+run_test_health() {
+  uv run pre-commit run test-health \
+    --all-files \
+    --hook-stage pre-push \
+    --show-diff-on-failure
+}
+
+run_commit_policy() {
+  # commit-msg hooks cannot run retroactively on GitHub API commits. Commitizen's
+  # range check is the CI-equivalent for every commit unique to this change.
+  uv run cz check --rev-range "${base_ref}..${head_ref}"
+}
+
+case "${phase}" in
+  files)
+    run_file_policy
+    ;;
+  repository-health)
+    run_repository_health
+    ;;
+  lock)
+    run_lock_health
+    ;;
+  test-health)
+    run_test_health
+    ;;
+  commits)
+    run_commit_policy
+    ;;
+  all)
+    run_file_policy
+    run_repository_health
+    run_lock_health
+    run_test_health
+    run_commit_policy
+    ;;
+  *)
+    echo "unknown policy phase: ${phase}" >&2
+    echo "expected one of: files, repository-health, lock, test-health, commits, all" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/dev/precommit_ci.sh
+++ b/scripts/dev/precommit_ci.sh
@@ -8,9 +8,9 @@ phase="${3:-all}"
 run_file_policy() {
   uv run pre-commit validate-config
 
-  # CI ownership boundary: Ruff is verified by Lint / blocking and repository
-  # health has its own Policy step. The file-policy phase owns only repository
-  # hygiene and notebook normalization.
+  # CI ownership boundary: Ruff belongs to Lint and repository-health belongs
+  # to the static-check lane. This phase owns file hygiene and notebook
+  # normalization only.
   SKIP=ruff-check,ruff-format,repository-health \
     uv run pre-commit run \
       --from-ref "${base_ref}" \
@@ -19,25 +19,8 @@ run_file_policy() {
       --show-diff-on-failure
 }
 
-run_repository_health() {
-  uv run pre-commit run repository-health \
-    --all-files \
-    --hook-stage pre-commit \
-    --show-diff-on-failure
-}
-
 run_lock_health() {
-  uv run pre-commit run uv-lock-check \
-    --all-files \
-    --hook-stage pre-push \
-    --show-diff-on-failure
-}
-
-run_test_health() {
-  uv run pre-commit run test-health \
-    --all-files \
-    --hook-stage pre-push \
-    --show-diff-on-failure
+  uv lock --check
 }
 
 run_commit_policy() {
@@ -50,28 +33,20 @@ case "${phase}" in
   files)
     run_file_policy
     ;;
-  repository-health)
-    run_repository_health
-    ;;
   lock)
     run_lock_health
-    ;;
-  test-health)
-    run_test_health
     ;;
   commits)
     run_commit_policy
     ;;
   all)
     run_file_policy
-    run_repository_health
     run_lock_health
-    run_test_health
     run_commit_policy
     ;;
   *)
     echo "unknown policy phase: ${phase}" >&2
-    echo "expected one of: files, repository-health, lock, test-health, commits, all" >&2
+    echo "expected one of: files, lock, commits, all" >&2
     exit 2
     ;;
 esac


### PR DESCRIPTION
## Summary

Follow up on the gate opacity exposed by PR #109 and the recurring GitHub-hosted runner apt stalls.

## Gate ownership and visibility

Each merge-critical responsibility now has one CI owner, while local hooks remain fast mirrors for early feedback:

- **Policy / `policy`**: file hygiene + notebook normalization, `uv lock --check`, and Commitizen range validation;
- **Lint / `blocking`**: Ruff and repository-health, shown as separate named steps;
- **Fast tests with coverage**: fast pytest plus full test-suite health, shown separately;
- **Integration tests**: cross-module integration pytest only;
- **Docker build**: native/container runtime contract, including the Cairo drawing backend;
- **advisory lint**: mypy/security checks remain non-blocking.

The authoritative Policy job now runs directly on every PR (including same-repository PRs) and on `main` after merge. Feature-branch push duplication is removed, so a policy failure is visible on the PR that owns it.

`scripts/dev/precommit_ci.sh` exposes named phases for the Policy workflow instead of one opaque catch-all step. Ruff/repository-health/test-health are not replayed there because they have explicit owners in Lint/Test.

Full-history Policy/Lint jobs use `actions/checkout` partial clone (`filter: blob:none`) so merge-base and Commitizen history remain available without downloading historical file blobs.

## Notebook normalization

`nbstripout` now runs with `--keep-id`. Outputs/execution state/transient metadata remain normalized, but stable or descriptive Jupyter cell IDs are preserved instead of being mechanically renumbered.

## Apt/native dependency boundary

The repeated failures showed that timeout/retry tuning is not sufficient: a GitHub-hosted runner can spend the entire timeout downloading Cairo's transitive development packages, and `apt-get update` can then stall on the same Azure mirror.

This PR therefore removes host apt from the merge-critical Fast and Integration jobs entirely:

- Fast uses `uv sync --locked --extra storage`;
- Integration uses `uv sync --locked --extra storage`;
- neither requests system packages;
- the Cairo/drawing backend is validated in the required Docker build gate instead.

The PR Docker smoke image is built with `drawing storage`. Its native Cairo toolchain lives in the Dockerfile's stable/cacheable system layer, and the smoke step installs the locked dev group into the image environment and runs `tests/visualizer/test_hamiltonian_graph.py`, including the real igraph-Cairo SVG path. This retains required drawing coverage without making every Fast/Integration runner depend on Ubuntu apt mirrors.

The shared setup action still has a bounded direct-install/fallback path for workflows that intentionally require host native packages (for example scheduled scientific validation), but ordinary required test lanes no longer use it.

## Compatibility

Required check/job names remain stable (`policy`, `blocking`, Fast tests, Integration tests, Docker build), so branch-protection semantics do not need to be loosened or renamed.